### PR TITLE
chore: release v0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,7 +1632,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dxc"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "dxc-components",
  "dxc-hooks",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "dxc-components"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "dioxus",
  "dxc-hooks",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "dxc-examples"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "dioxus",
  "dxc",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "dxc-hooks"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "dxc-types",
  "once_cell",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "dxc-macros"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "darling 0.21.2",
  "dioxus",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "dxc-themes"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "dioxus",
  "grass",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "dxc-types"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "dioxus",
  "serde",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "dxc-utils"
-version = "0.1.8"
+version = "0.1.9"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 [workspace.package]
 edition = "2021"
 rust-version = "1.89.0"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["efahnjoe"]
 license = "MIT"
 repository = "https://github.com/efahnjoe/dxc"
@@ -23,14 +23,14 @@ readme = "README.md"
 
 [workspace.dependencies]
 dioxus = { version = "0.6.3", features = ["router", "fullstack"] }
-dxc = { version = "0.1.8", path = "packages/dxc" }
-dxc-components = { version = "0.1.8", path = "packages/components" }
-dxc-hooks = { version = "0.1.8", path = "packages/hooks" }
+dxc = { version = "0.1.9", path = "packages/dxc" }
+dxc-components = { version = "0.1.9", path = "packages/components" }
+dxc-hooks = { version = "0.1.9", path = "packages/hooks" }
 dxc-icons = "0.1.3"
-dxc-macros = { version = "0.1.8", path = "packages/macros" }
-dxc-themes = { version = "0.1.8", path = "packages/themes" }
-dxc-types = { version = "0.1.8", path = "packages/types" }
-dxc-utils = { version = "0.1.8", path = "packages/utils" }
+dxc-macros = { version = "0.1.9", path = "packages/macros" }
+dxc-themes = { version = "0.1.9", path = "packages/themes" }
+dxc-types = { version = "0.1.9", path = "packages/types" }
+dxc-utils = { version = "0.1.9", path = "packages/utils" }
 once_cell = "1.21.3"
 serde = { version = "1.0.219", features = ["derive"] }
 strum = { version = "0.27.2", features = ["derive"] }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,9 +6,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-v0.1.8...dxc-v0.1.9) - 2025-08-28
-
-### Other
-
-- add CHANGELOG.md files for dxc packages

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-hooks-v0.1.8...dxc-hooks-v0.1.9) - 2025-08-28
+
+### Other
+
+- add CHANGELOG.md files for dxc packages

--- a/packages/macros/CHANGELOG.md
+++ b/packages/macros/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-macros-v0.1.8...dxc-macros-v0.1.9) - 2025-08-28
+
+### Other
+
+- add CHANGELOG.md files for dxc packages

--- a/packages/themes/CHANGELOG.md
+++ b/packages/themes/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-themes-v0.1.8...dxc-themes-v0.1.9) - 2025-08-28
+
+### Other
+
+- add CHANGELOG.md files for dxc packages

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-types-v0.1.8...dxc-types-v0.1.9) - 2025-08-28
+
+### Other
+
+- add CHANGELOG.md files for dxc packages

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-utils-v0.1.8...dxc-utils-v0.1.9) - 2025-08-28
+
+### Other
+
+- add CHANGELOG.md files for dxc packages


### PR DESCRIPTION



## 🤖 New release

* `dxc-types`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `dxc-hooks`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `dxc-macros`: 0.1.8 -> 0.1.9
* `dxc-themes`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `dxc-components`: 0.1.8 -> 0.1.9
* `dxc-utils`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `dxc`: 0.1.8 -> 0.1.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `dxc-types`

<blockquote>

## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-types-v0.1.8...dxc-types-v0.1.9) - 2025-08-28

### Other

- add CHANGELOG.md files for dxc packages
</blockquote>

## `dxc-hooks`

<blockquote>

## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-hooks-v0.1.8...dxc-hooks-v0.1.9) - 2025-08-28

### Other

- add CHANGELOG.md files for dxc packages
</blockquote>

## `dxc-macros`

<blockquote>

## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-macros-v0.1.8...dxc-macros-v0.1.9) - 2025-08-28

### Other

- add CHANGELOG.md files for dxc packages
</blockquote>

## `dxc-themes`

<blockquote>

## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-themes-v0.1.8...dxc-themes-v0.1.9) - 2025-08-28

### Other

- add CHANGELOG.md files for dxc packages
</blockquote>


## `dxc-utils`

<blockquote>

## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-utils-v0.1.8...dxc-utils-v0.1.9) - 2025-08-28

### Other

- add CHANGELOG.md files for dxc packages
</blockquote>

## `dxc`

<blockquote>

## [0.1.9](https://github.com/efahnjoe/dxc/compare/dxc-v0.1.8...dxc-v0.1.9) - 2025-08-28

### Other

- add CHANGELOG.md files for dxc packages
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).